### PR TITLE
Implement FAQ, chat, and admin API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 PORT=8000
 NODE_ENV=development
 JWT_SECRET=your_jwt_secret_key_here
+DATABASE_URL="file:./dev.db"
+OPENAI_API_KEY=your_openai_key

--- a/README.md
+++ b/README.md
@@ -153,6 +153,28 @@ fetch('/auth/me', {
 
 ---
 
+## 📚 FAQ, Chat, and Admin Endpoints
+
+### FAQ
+
+- `GET /faqs` - List FAQs (supports `page` and `limit` query params)
+- `GET /faqs/:id` - Retrieve a single FAQ
+- `GET /faqs/search?keyword=foo` - Keyword search
+- `POST /faqs` - Create FAQ (admin only)
+- `PUT /faqs/:id` - Update FAQ (admin only)
+- `DELETE /faqs/:id` - Delete FAQ (admin only)
+
+### Chat
+
+- `POST /chat` - Ask a question (requires auth). The server searches FAQs and calls the OpenAI API before saving the chat log.
+
+### Admin
+
+- `GET /admin/chat-logs` - List all chat logs
+- `GET /admin/report/chat-logs` - Simple aggregated report
+
+---
+
 ## 💡 Pre-commit Hook
 
 This template uses **Husky** and **lint-staged** to lint & format files before commits.

--- a/prisma/migrations/20250528090319_add_faq_chatlog/migration.sql
+++ b/prisma/migrations/20250528090319_add_faq_chatlog/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "FAQ" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "question" TEXT NOT NULL,
+    "answer" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "ChatLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT,
+    "question" TEXT NOT NULL,
+    "answer" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ChatLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "name" TEXT,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "name", "password", "updatedAt") SELECT "createdAt", "email", "id", "name", "password", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,25 @@ model User {
   email     String   @unique
   password  String
   name      String?
+  isAdmin   Boolean  @default(false)
+  chatLogs  ChatLog[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model FAQ {
+  id        String   @id @default(uuid())
+  question  String
+  answer    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model ChatLog {
+  id        String   @id @default(uuid())
+  userId    String?
+  user      User?    @relation(fields: [userId], references: [id])
+  question  String
+  answer    String
+  createdAt DateTime @default(now())
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,9 @@ import dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import authRoutes from './routes/auth';
+import faqRoutes from './routes/faqs';
+import chatRoutes from './routes/chat';
+import adminRoutes from './routes/admin';
 import { prisma } from './lib/prisma';
 
 // Load environment variables
@@ -32,6 +35,9 @@ app.get('/', (_req, res) => {
 
 // Auth routes - add /api prefix
 app.use('/auth', authRoutes);
+app.use('/faqs', faqRoutes);
+app.use('/chat', chatRoutes);
+app.use('/admin', adminRoutes);
 
 // For checking that Prisma is connected
 app.get('/debug/db', async (_req, res) => {

--- a/src/middleware/admin.ts
+++ b/src/middleware/admin.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const adminMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!req.user || !req.user.isAdmin) {
+    return res.status(403).json({ message: 'Admin access required' });
+  }
+  return next();
+};

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { prisma } from '../lib/prisma';
+import { authMiddleware } from '../middleware/auth';
+import { adminMiddleware } from '../middleware/admin';
+
+const router = Router();
+
+router.use(authMiddleware, adminMiddleware);
+
+router.get('/chat-logs', async (req, res) => {
+  const logs = await prisma.chatLog.findMany({
+    include: { user: { select: { id: true, email: true } } },
+    orderBy: { createdAt: 'desc' },
+  });
+  res.json(logs);
+});
+
+router.get('/report/chat-logs', async (_req, res) => {
+  const logs = await prisma.chatLog.groupBy({
+    by: ['createdAt'],
+    _count: { id: true },
+  });
+  res.json(logs);
+});
+
+export default router;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -37,7 +37,7 @@ router.post('/login', async (req: Request, res: Response) => {
     }
 
     // Generate JWT and set cookie
-    signToken({ id: user.id, email: user.email }, res);
+    signToken({ id: user.id, email: user.email, isAdmin: user.isAdmin }, res);
 
     // Return user data (excluding password)
     const { password: _password, ...userData } = user;
@@ -85,7 +85,7 @@ router.post('/signup', async (req: Request, res: Response) => {
     });
 
     // Generate JWT and set cookie
-    signToken({ id: user.id, email: user.email }, res);
+    signToken({ id: user.id, email: user.email, isAdmin: user.isAdmin }, res);
 
     // Return user data (excluding password)
     const { password: _password, ...userData } = user;

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -1,0 +1,87 @@
+import { Router, Request, Response } from 'express';
+import { prisma } from '../lib/prisma';
+import { authMiddleware } from '../middleware/auth';
+import type { UserPayload } from '../utils/jwt';
+
+const router = Router();
+
+interface ChatRequest {
+  question: string;
+}
+
+interface AuthRequest extends Request {
+  user?: UserPayload;
+}
+
+async function callOpenAI(
+  question: string,
+  faqs: { question: string; answer: string }[]
+): Promise<string> {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY not set');
+  }
+  const messages = [
+    {
+      role: 'system',
+      content: 'You are an assistant answering user questions based on FAQs.',
+    },
+    ...faqs.map((f) => ({
+      role: 'system',
+      content: `Q: ${f.question}\nA: ${f.answer}`,
+    })),
+    { role: 'user', content: question },
+  ];
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
+      messages,
+    }),
+  });
+  interface OpenAIResponse {
+    choices: { message: { content: string } }[];
+  }
+  const data = (await response.json()) as OpenAIResponse;
+  return data.choices?.[0]?.message?.content || '';
+}
+
+router.post('/', authMiddleware, async (req: AuthRequest, res: Response) => {
+  const { question } = req.body as ChatRequest;
+  if (!question) {
+    return res.status(400).json({ message: 'Question is required' });
+  }
+  // fetch related FAQs
+  const faqs = await prisma.fAQ.findMany({
+    where: {
+      OR: [
+        { question: { contains: question } },
+        { answer: { contains: question } },
+      ],
+    },
+    take: 3,
+  });
+
+  let answer = '';
+  try {
+    answer = await callOpenAI(question, faqs);
+  } catch (err) {
+    console.error('OpenAI error', err);
+    return res.status(500).json({ message: 'Failed to get answer' });
+  }
+
+  await prisma.chatLog.create({
+    data: {
+      question,
+      answer,
+      userId: req.user?.id,
+    },
+  });
+
+  res.json({ answer });
+});
+
+export default router;

--- a/src/routes/faqs.ts
+++ b/src/routes/faqs.ts
@@ -1,0 +1,71 @@
+import { Router } from 'express';
+import { prisma } from '../lib/prisma';
+import { authMiddleware } from '../middleware/auth';
+import { adminMiddleware } from '../middleware/admin';
+
+const router = Router();
+
+// GET /faqs - list FAQs with optional pagination
+router.get('/', async (req, res) => {
+  const page = parseInt(req.query.page as string) || 1;
+  const limit = parseInt(req.query.limit as string) || 10;
+  const skip = (page - 1) * limit;
+  const faqs = await prisma.fAQ.findMany({
+    skip,
+    take: limit,
+    orderBy: { createdAt: 'desc' },
+  });
+  res.json(faqs);
+});
+
+// GET /faqs/search?keyword=xxx - search FAQs
+router.get('/search', async (req, res) => {
+  const keyword = req.query.keyword as string;
+  if (!keyword) return res.json([]);
+  const faqs = await prisma.fAQ.findMany({
+    where: {
+      OR: [
+        { question: { contains: keyword } },
+        { answer: { contains: keyword } },
+      ],
+    },
+  });
+  res.json(faqs);
+});
+
+// GET /faqs/:id - get specific FAQ
+router.get('/:id', async (req, res) => {
+  const faq = await prisma.fAQ.findUnique({ where: { id: req.params.id } });
+  if (!faq) return res.status(404).json({ message: 'FAQ not found' });
+  res.json(faq);
+});
+
+// POST /faqs - create FAQ (admin)
+router.post('/', authMiddleware, adminMiddleware, async (req, res) => {
+  const { question, answer } = req.body;
+  if (!question || !answer) {
+    return res
+      .status(400)
+      .json({ message: 'Question and answer are required' });
+  }
+  const faq = await prisma.fAQ.create({ data: { question, answer } });
+  res.status(201).json(faq);
+});
+
+// PUT /faqs/:id - update FAQ (admin)
+router.put('/:id', authMiddleware, adminMiddleware, async (req, res) => {
+  const { question, answer } = req.body;
+  const faq = await prisma.fAQ.update({
+    where: { id: req.params.id },
+    data: { question, answer },
+  });
+  res.json(faq);
+});
+
+// DELETE /faqs/:id - delete FAQ (admin)
+router.delete('/:id', authMiddleware, adminMiddleware, async (req, res) => {
+  await prisma.fAQ.delete({ where: { id: req.params.id } });
+  res.status(204).end();
+});
+
+export default router;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -5,6 +5,7 @@ import { Response } from 'express';
 export interface UserPayload {
   id: string;
   email: string;
+  isAdmin?: boolean;
 }
 
 // Sign JWT token and store in HTTP-Only Cookie
@@ -14,7 +15,7 @@ export const signToken = (user: UserPayload, res: Response): string => {
   }
 
   const token = jwt.sign(
-    { id: user.id, email: user.email },
+    { id: user.id, email: user.email, isAdmin: user.isAdmin },
     process.env.JWT_SECRET,
     { expiresIn: '7d' }
   );


### PR DESCRIPTION
## Summary
- extend DB schema with FAQ and ChatLog models
- create middleware for admin access
- implement `/faqs`, `/chat`, and `/admin` routes
- include admin field in JWT payload
- document new endpoints

## Testing
- `npx eslint src`
- `npx tsc`